### PR TITLE
Add runtime dependencies needed to run a langserver "built from source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,12 @@ To setup the repo locally run:
 git clone --recursive https://github.com/vscode-langservers/vscode-html-languageserver-bin
 cd vscode-html-languageserver-bin
 npm install
-npm run pack
+npm run build
 ```
+
+This will produce `*.js` files, including the primary executable `htmlServerMain.js`, in a folder named `dist`.
+
+Run `node /path/to/dist/htmlServerMain.js`, with or without arguments, to start the language server.
 
 ## Versioning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,72 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
       "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA=="
+    },
+    "vscode-css-languageservice": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-3.0.12.tgz",
+      "integrity": "sha512-+FLQ9LcukIhnxaGTjDOqb3Nb1hesz9BLXf5yeoZxUsuK7joADPLPdxLwlZugFcMAvgmtnaFIGnzkQhGOVqf5yw==",
+      "requires": {
+        "vscode-languageserver-types": "^3.13.0",
+        "vscode-nls": "^4.0.0"
+      }
+    },
+    "vscode-html-languageservice": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-2.1.10.tgz",
+      "integrity": "sha512-nuzLd7a3J+Ttvk/9Pg2H0vS7rV2oZRfsQYPRheHnUNJNqivkcieSI8ZCGvZjmr3NDBG2QQaRFambnCtceYAj3A==",
+      "requires": {
+        "vscode-languageserver-types": "^3.13.0",
+        "vscode-nls": "^4.0.0",
+        "vscode-uri": "^1.0.6"
+      }
+    },
+    "vscode-jsonrpc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
+      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+    },
+    "vscode-languageserver": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.1.0.tgz",
+      "integrity": "sha512-CIsrgx2Y5VHS317g/HwkSTWYBIQmy0DwEyZPmB2pEpVOhYFwVsYpbiJwHIIyLQsQtmRaO4eA2xM8KPjNSdXpBw==",
+      "requires": {
+        "vscode-languageserver-protocol": "3.13.0",
+        "vscode-uri": "^1.0.6"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
+      "integrity": "sha512-2ZGKwI+P2ovQll2PGAp+2UfJH+FK9eait86VBUdkPd9HRlm8e58aYT9pV/NYanHOcp3pL6x2yTLVCFMcTer0mg==",
+      "requires": {
+        "vscode-jsonrpc": "^4.0.0",
+        "vscode-languageserver-types": "3.13.0"
+      }
+    },
+    "vscode-languageserver-protocol-foldingprovider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol-foldingprovider/-/vscode-languageserver-protocol-foldingprovider-2.0.1.tgz",
+      "integrity": "sha512-N8bOS8i0xuQMn/y0bijyefDbOsMl6hiH6LDREYWavTLTM5jbj44EiQfStsbmAv/0eaFKkL/jf5hW7nWwBy2HBw==",
+      "requires": {
+        "vscode-languageserver-protocol": "^3.7.2",
+        "vscode-languageserver-types": "^3.7.2"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
+      "integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
+    },
+    "vscode-nls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.0.0.tgz",
+      "integrity": "sha512-qCfdzcH+0LgQnBpZA53bA32kzp9rpq/f66Som577ObeuDlFIrtbEJ+A/+CCxjIh4G8dpJYNCKIsxpRAHIfsbNw=="
+    },
+    "vscode-uri": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "chalk": "^2.3.0"
   },
   "dependencies": {
-    "typescript": "^2.9.1"
+    "typescript": "^2.9.1",
+    "vscode-css-languageservice": "^3.0.12",
+    "vscode-html-languageservice": "^2.1.10",
+    "vscode-languageserver": "^5.1.0",
+    "vscode-languageserver-protocol-foldingprovider": "^2.0.1"
   }
 }


### PR DESCRIPTION
Adds npm packages to `package.json` that are needed to run the transpiled `htmlServerMain.js` file from the command line, e.g. with: `node ~/vscode-html-languageserver-bin/dist/htmlServerMain.js --stdio`.

Essentially the same as https://github.com/vscode-langservers/vscode-css-languageserver-bin/pull/5.